### PR TITLE
Fix for dateparser parsing current datetime from invalid string

### DIFF
--- a/APP/ui/includes/find_dates.py
+++ b/APP/ui/includes/find_dates.py
@@ -202,6 +202,9 @@ class FindDates:
     def check_year_range(self, regex_result, settings_str):
         # def check_year_range(self, date_str, settings_str):
         date_obj = dateparser.parse(regex_result.group(0), settings=settings_str)
+        now = datetime.datetime.now()
+        if not date_obj or abs((now - date_obj).total_seconds()) < 5:
+            date_obj = None
         if date_obj:
             act_value = f"{date_obj.day:02d}.{date_obj.month:02d}.{date_obj.year:04d}"
             logging.debug(f'Found date {act_value}')


### PR DESCRIPTION
…f.99647/post-1188390

- dateparser sometimes tries to make sense of any passed string and returns the current datetime instead of None for an invalid string. Tried PREFER_DATES_FROM=past and strict_parsing=True without success. It seems the best option is to compare the parsed the to the current datetime.